### PR TITLE
Prevent fd leak in vedis.c

### DIFF
--- a/src/vedis.c
+++ b/src/vedis.c
@@ -12924,6 +12924,7 @@ static sxi32 SyOSUtilRandomSeed(void *pBuf, sxu32 nLen, void *pUnused)
 	fd = open("/dev/urandom", O_RDONLY);
 	if (fd >= 0 ){
 		if( read(fd, zBuf, nLen) > 0 ){
+			close(fd);
 			return SXRET_OK;
 		}
 		/* FALL THRU */


### PR DESCRIPTION
An error has been made in the SyOSUtilRandomSeed, when running for a long time, leads to a leak of file descriptors, since the /dev/urandom descriptor is not closed anywhere