### PR TITLE
fix: add cpython 3.x.x compatibility

### DIFF
--- a/vedis.pyx
+++ b/vedis.pyx
@@ -28,6 +28,10 @@ except ImportError:
         _fsencoding = _getfsencoding()
     fsencode = lambda s: s.encode(_fsencoding)
 
+# Python 3.x has long as int
+# > PEP 237: Essentially, long renamed to int. That is, there is only one 
+# > built-in integral type, named int; but it behaves mostly like the old long type.
+# https://docs.python.org/3/whatsnew/3.0.html
 try:
     long
 except NameError:

--- a/vedis.pyx
+++ b/vedis.pyx
@@ -28,6 +28,11 @@ except ImportError:
         _fsencoding = _getfsencoding()
     fsencode = lambda s: s.encode(_fsencoding)
 
+try:
+    long
+except NameError:
+    long = int
+
 
 cdef extern from "src/vedis.h":
     ctypedef struct vedis


### PR DESCRIPTION
Add compatibility for cpython 3.x.x

```
Run uv pip install \
  × Failed to build `vedis==0.7.2`
  ├─▶ The build backend returned an error
  ╰─▶ Call to
      `setuptools.build_meta:__legacy__.prepare_metadata_for_build_wheel`
      failed (exit status: 1)

      [stdout]
      Compiling vedis.pyx because it changed.
      [1/1] Cythonizing vedis.pyx

      [stderr]

      Error compiling Cython file:
      ------------------------------------------------------------
      ...
          if isinstance(python_value, unicode):
              encoded_value = encode(python_value)
              vedis_value_string(ptr, encoded_value, -1)
          elif isinstance(python_value, bytes):
              vedis_value_string(ptr, python_value, -1)
          elif isinstance(python_value, (int, long)):
                                              ^
      ------------------------------------------------------------

      vedis.pyx:968:40: undeclared name not builtin: long
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File
      "/home/runner/_work/_temp/setup-uv-cache/builds-v0/.tmpOG1vBt/lib/python3.11/site-packages/setuptools/build_meta.py",
      line 374, in prepare_metadata_for_build_wheel
          self.run_setup()
        File
      "/home/runner/_work/_temp/setup-uv-cache/builds-v0/.tmpOG1vBt/lib/python3.11/site-packages/setuptools/build_meta.py",
      line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File
      "/home/runner/_work/_temp/setup-uv-cache/builds-v0/.tmpOG1vBt/lib/python3.11/site-packages/setuptools/build_meta.py",
      line 317, in run_setup
          exec(code, locals())
        File "<string>", line 34, in <module>
        File
      "/home/runner/_work/_temp/setup-uv-cache/builds-v0/.tmpOG1vBt/lib/python3.11/site-packages/Cython/Build/Dependencies.py",
      line 1145, in cythonize
          cythonize_one(*args)
        File
      "/home/runner/_work/_temp/setup-uv-cache/builds-v0/.tmpOG1vBt/lib/python3.11/site-packages/Cython/Build/Dependencies.py",
      line 1289, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: vedis.pyx

      hint: This usually indicates a problem with the package or the build
      environment.
```